### PR TITLE
chore: add additional LazyList tests

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2004,6 +2004,23 @@ Line 1
         self.assertEqual(list(reversed(LazyList(it))[::-1]), it)
         self.assertEqual(list(reversed(LazyList(it))[1:3:7]), it[::-1][1:3:7])
 
+        ll = LazyList(it)
+        A = iter(ll)
+        self.assertEqual(next(A), it[0])
+        B = iter(ll)
+        self.assertEqual(next(B), it[0])
+        self.assertEqual(next(B), it[1])
+        self.assertEqual(next(A), it[1])
+        self.assertEqual(next(B), next(A))
+        self.assertEqual(ll[7], it[7])
+        # Reading from the cache now
+        self.assertEqual(next(A), next(B))
+        self.assertEqual(next(B), it[4])
+        # Finish the B iterator
+        self.assertEqual(list(B), it[5:])
+        # Ensure the other iterator was not truncated
+        self.assertEqual(list(A), it[4:])
+
     def test_LazyList_laziness(self):
 
         def test(ll, idx, val, cache):


### PR DESCRIPTION
Verify the behavior of `LazyList` iterators.

## Original code test failure

```
=================================== FAILURES ===================================
____________________________ TestUtil.test_LazyList ____________________________
test/test_utils.py:2013: in test_LazyList
    self.assertEqual(next(A), it[1])
E   AssertionError: 2 != 1
```

https://github.com/tcely/yt-dlp/blob/807d65d111801287db335e0497b318cf37e2bc26/test/test_utils.py#L1981-L2013

